### PR TITLE
fix: prevent default forwarding via "this.event"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ interceptor.on('connection', ({ client, server }) => {
 
   const io = toSocketIoConnection({ client, server })
 
-  io.client.on('greeting', (message) => {
+  io.client.on('greeting', (event, message) => {
     // Using the wrapper, you get the decoded messages,
     // as well as support for custom event listeners.
     console.log(message) // "Hello, John!"
@@ -56,7 +56,7 @@ export const handlers = [
   ws.on('connection', ({ client, server }) => {
     const io = toSocketIoConnection({ client, server })
 
-    io.on('hello', (name) => {
+    io.on('hello', (event, name) => {
       console.log('client sent hello:', name)
     })
   }),

--- a/src/io.ts
+++ b/src/io.ts
@@ -18,18 +18,9 @@ import {
 const encoder = new Encoder()
 const decoder = new Decoder()
 
-Event
-
-type MessageListenerContext = {
-  /**
-   * Original `MessageEvent` instance of the intercepted message.
-   */
-  // @ts-expect-error Bug in @types/node: Missing annotation
-  event: MessageEvent
-}
-
 type BoundMessageListener = (
-  this: MessageListenerContext,
+  // @ts-expect-error Bug in @types/node: Missing annotation
+  event: MessageEvent,
   ...data: Array<WebSocketRawData>
 ) => void
 
@@ -75,12 +66,7 @@ class SocketIoConnection {
           const [sentEvent, ...data] = decodedSocketIoPacket.data
 
           if (sentEvent === event) {
-            /**
-             * @note Bind the listener function to expose the
-             * original MessageEvent instance to the listener.
-             * That way, the message forwarding can be prevented.
-             */
-            listener.apply({ event: messageEvent }, data)
+            listener.call(undefined, messageEvent, ...data)
           }
         })
 

--- a/test/io.test.ts
+++ b/test/io.test.ts
@@ -42,7 +42,7 @@ it('intercepts custom outgoing client event', async () => {
 
     const { client } = toSocketIoConnection(connection)
 
-    client.on('hello', (name) => {
+    client.on('hello', (event, name) => {
       outgoingDataPromise.resolve(name)
     })
   })
@@ -67,7 +67,7 @@ it('sends a mocked custom incoming server event', async () => {
 
     const { client } = toSocketIoConnection(connection)
 
-    client.on('hello', (name) => {
+    client.on('hello', (event, name) => {
       client.emit('greetings', `Hello, ${name}!`)
     })
   })
@@ -105,7 +105,7 @@ it('intercepts incoming server event', async () => {
 
     const { server } = toSocketIoConnection(connection)
 
-    server.on('greeting', (message) => {
+    server.on('greeting', (event, message) => {
       incomingServerDataPromise.resolve(message)
     })
   })
@@ -149,10 +149,10 @@ it('modifies incoming server event', async () => {
       connection.server.send(event.data)
     })
 
-    io.server.on('greeting', function (message) {
+    io.server.on('greeting', (event, message) => {
       incomingServerDataPromise.resolve(message)
 
-      this.event.preventDefault()
+      event.preventDefault()
       io.client.emit('greeting', { id: 2, text: 'Hello, Sarah!' })
     })
   })

--- a/test/io.test.ts
+++ b/test/io.test.ts
@@ -149,21 +149,11 @@ it('modifies incoming server event', async () => {
       connection.server.send(event.data)
     })
 
-    io.server.on('greeting', (message) => {
+    io.server.on('greeting', function (message) {
       incomingServerDataPromise.resolve(message)
 
-      /**
-       * @fixme Forward the original "event" instance
-       * so its default can be prevented (cancel forwarding).
-       */
-      /**
-       * @fixme How to prevent forwarding for multi-events?
-       * (e.g. receiving Blob from the server). There will be
-       * multiple "message" events dispatched.
-       */
-
-      // event.preventDefault()
-      // io.client.emit('greeting', { id: 2, text: 'Hello, Sarah!' })
+      this.event.preventDefault()
+      io.client.emit('greeting', { id: 2, text: 'Hello, Sarah!' })
     })
   })
 


### PR DESCRIPTION
- Fixes #1 

## Changes

Binds the `server.on()` listener to a custom context that exposes the `event` property standing for the original `MessageEvent` instance behind the intercepted Socket.IO message. 